### PR TITLE
Fix memory-card version upgrade break wechaty-puppet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Abstract Puppet for Wechaty",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "file-box": "^0.8.22",
     "git-scripts": "^0.2.1",
     "markdownlint-cli": "^0.12.0",
-    "memory-card": "^0.4.5",
+    "memory-card": "^0.5.1",
     "shx": "^0.3.1",
     "sinon": "^6.0.1",
     "ts-node": "^7.0.0",
@@ -66,7 +66,7 @@
     }
   },
   "peerDependencies": {
-    "memory-card": "^0.4.5",
+    "memory-card": "^0.5.1",
     "file-box": "^0.8.22"
   },
   "dependencies": {

--- a/src/puppet.spec.ts
+++ b/src/puppet.spec.ts
@@ -402,7 +402,7 @@ test('setMemory() memory without name', async t => {
 
 test('setMemory() memory with a name', async t => {
   const puppet = new PuppetTest()
-  const memory = new MemoryCard('name')
+  const memory = new MemoryCard({ name: 'name' })
 
   t.doesNotThrow(() => puppet.setMemory(memory), 'should not throw when set a named memory first time ')
   t.throws(() => puppet.setMemory(memory), 'should throw when set a named memory second time')

--- a/src/puppet.ts
+++ b/src/puppet.ts
@@ -228,7 +228,7 @@ export abstract class Puppet extends EventEmitter {
       this.constructor.name,
       '>',
       '(',
-      this.memory.name || '',
+      this.memory.options && this.memory.options.name || '',
       ')',
     ].join('')
   }
@@ -249,8 +249,8 @@ export abstract class Puppet extends EventEmitter {
   public setMemory (memory: MemoryCard): void {
     log.verbose('Puppet', 'setMemory()')
 
-    if (this.memory.name) {
-      throw new Error('puppet has already had a memory with name set: ' + this.memory.name)
+    if (this.memory.options && this.memory.options.name) {
+      throw new Error('puppet has already had a memory with name set: ' + this.memory.options.name)
     }
 
     this.memory = memory


### PR DESCRIPTION
```shell
error TS2345: Argument of type 'import("/Users/yuangao/git/wechaty/wechaty/node_modules/memory-card/dist/src/memory-card").MemoryCard' is not assignable to parameter of type 'import("/Users/yuangao/git/wechaty/wechaty-puppet/node_modules/memory-card/dist/src/memory-card").MemoryCard'.
  Property 'name' is missing in type 'MemoryCard'.

572     puppetInstance.setMemory(puppetMemory)
```