### PR TITLE
fix: when adding a use to a room, it may throw an undefined error

### DIFF
--- a/src/puppet.ts
+++ b/src/puppet.ts
@@ -1191,7 +1191,7 @@ export abstract class Puppet extends EventEmitter {
      */
     const rawPayload = await this.roomMemberRawPayload(roomId, contactId)
     if (!rawPayload) {
-      throw new Error('contact(' + contactId + ') is not in the Room(' + roomId + ')');
+      throw new Error('contact(' + contactId + ') is not in the Room(' + roomId + ')')
     }
     const payload    = await this.roomMemberRawPayloadParser(rawPayload)
 

--- a/src/puppet.ts
+++ b/src/puppet.ts
@@ -1190,6 +1190,9 @@ export abstract class Puppet extends EventEmitter {
      * 2. Cache not found
      */
     const rawPayload = await this.roomMemberRawPayload(roomId, contactId)
+    if (!rawPayload) {
+      throw new Error('contact(' + contactId + ') is not in the Room(' + roomId + ')');
+    }
     const payload    = await this.roomMemberRawPayloadParser(rawPayload)
 
     this.cacheRoomMemberPayload.set(CACHE_KEY, payload)


### PR DESCRIPTION
https://github.com/botorange/wechaty-puppet-padpro/blob/master/src/puppet-padpro.ts#L1438-L1447

for some reason, `this.padproManager.GrpcAddRoomMember` will fail without any errors. then we call `this.roomMemberPayload(roomId, contactId)` will throw an error like this:

```
(node:22575) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'bigHeadUrl' of undefined
    at PuppetPadpro.<anonymous> (/home/gcaufy/mine/code/wechaty/wepy-bot/node_modules/wechaty-puppet-padpro/dist/src/puppet-padpro.js:973:36)
    at Generator.next (<anonymous>)
    at /home/gcaufy/mine/code/wechaty/wepy-bot/node_modules/wechaty-puppet-padpro/dist/src/puppet-padpro.js:25:71
    at new Promise (<anonymous>)
    at __awaiter (/home/gcaufy/mine/code/wechaty/wepy-bot/node_modules/wechaty-puppet-padpro/dist/src/puppet-padpro.js:21:12)
    at PuppetPadpro.roomMemberRawPayloadParser (/home/gcaufy/mine/code/wechaty/wepy-bot/node_modules/wechaty-puppet-padpro/dist/src/puppet-padpro.js:971:16)
    at PuppetPadpro.<anonymous> (/home/gcaufy/mine/code/wechaty/wepy-bot/node_modules/wechaty-puppet/dist/src/puppet.js:736:40)
    at Generator.next (<anonymous>)
    at fulfilled (/home/gcaufy/mine/code/wechaty/wepy-bot/node_modules/wechaty-puppet/dist/src/puppet.js:22:58)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```